### PR TITLE
Add deprecation banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!WARNING]
+> **⚠️ DEPRECATED — this repository is no longer maintained.**
+>
+> This fork of [patw0929/react-intl-tel-input](https://github.com/patw0929/react-intl-tel-input)
+> existed for internal consumers only. `glia-hub` has dropped it in favour of
+> `react-phone-number-input` (BROW-2634); the sole remaining consumer is `visitor-app`.
+> It will be archived once that consumer migrates off it. Do not add new dependencies on it.
+
 # React-Intl-Tel-Input
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)


### PR DESCRIPTION
## Why

`glia-hub` no longer depends on this fork — it was removed in [salemove/glia-hub#11399](https://github.com/salemove/glia-hub/pull/11399); phone inputs there use `react-phone-number-input`. The only remaining consumer is `salemove/visitor-app`. The banner makes the deprecation unmissable for anyone landing here and warns against adding new dependencies on it; the repository is due to be archived once `visitor-app` migrates off it.

BROW-2634